### PR TITLE
Adding 'range' and 'flags' as optional options for specific situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,38 @@ vim.api.nvim_set_keymap("n", "<leader>rbf", "<CMD>SearchReplaceMultiBufferCFile<
 vim.o.inccommand = "split"
 ```
 
+### Additional Neovim
+
+```lua
+local opts = {}
+vim.keymap.set("v", "<C-r>", "<CMD>SearchReplaceSingleBufferVisualSelection<CR>", opts)
+vim.keymap.set("v", "<C-s>", "<CMD>SearchReplaceWithinVisualSelection<CR>", opts)
+vim.keymap.set("v", "<C-b>", "<CMD>SearchReplaceWithinVisualSelectionCWord<CR>", opts)
+
+vim.keymap.set("n", "<leader>ro", require("search-replace.single-buffer").open, opts)
+
+-- you can set range opts (read more in ':h range')
+vim.keymap.set("n", "<leader>rw", function() require("search-replace.single-buffer").cword({range = ",$"}) end, opts)
+
+-- you can set flags for specific situations (read more in "h :s_flags")
+vim.keymap.set("n", "<leader>rW", function() require("search-replace.single-buffer").cWORD({flags = "g"}) end, opts)
+
+-- you can set both
+vim.keymap.set("n", "<leader>re", function()
+  require("search-replace.single-buffer").expr({range = ",$", flags = "gc"})
+end, opts)
+vim.keymap.set("n", "<leader>rf", require("search-replace.single-buffer").cfile, opts)
+
+vim.keymap.set("n", "<leader>rbs", require("search-replace.multi-buffer").open, opts)
+vim.keymap.set("n", "<leader>rbw", require("search-replace.multi-buffer").cword, opts)
+vim.keymap.set("n", "<leader>rbW", require("search-replace.multi-buffer").cWORD, opts)
+vim.keymap.set("n", "<leader>rbe", require("search-replace.multi-buffer").expr, opts)
+vim.keymap.set("n", "<leader>rbf", require("search-replace.multi-buffer").cfile, opts)
+
+-- show the effects of a search / replace in a live preview window
+vim.o.inccommand = "split"
+```
+
 ### Lunarvim / Which-Key
 
 ``` lua
@@ -329,7 +361,7 @@ keymap = lvim.builtin.which_key.mappings
 keymap["r"] = { name = "SearchReplaceSingleBuffer" }
 
 keymap["r"]["s"] =
-  { "<CMD>SearchReplaceSingleBufferSelections<CR>", "SearchReplaceSingleBuffer [s]elction list" }
+  { "<CMD>SearchReplaceSingleBufferSelections<CR>", "SearchReplaceSingleBuffer [s]election list" }
 keymap["r"]["o"] = { "<CMD>SearchReplaceSingleBufferOpen<CR>", "[o]pen" }
 keymap["r"]["w"] = { "<CMD>SearchReplaceSingleBufferCWord<CR>", "[w]ord" }
 keymap["r"]["W"] = { "<CMD>SearchReplaceSingleBufferCWORD<CR>", "[W]ORD" }
@@ -339,7 +371,7 @@ keymap["r"]["f"] = { "<CMD>SearchReplaceSingleBufferCFile<CR>", "[f]ile" }
 keymap["r"]["b"] = { name = "SearchReplaceMultiBuffer" }
 
 keymap["r"]["b"]["s"] =
-  { "<CMD>SearchReplaceMultiBufferSelections<CR>","SearchReplaceMultiBuffer [s]elction list" }
+  { "<CMD>SearchReplaceMultiBufferSelections<CR>","SearchReplaceMultiBuffer [s]election list" }
 keymap["r"]["b"]["o"] = { "<CMD>SearchReplaceMultiBufferOpen<CR>", "[o]pen" }
 keymap["r"]["b"]["w"] = { "<CMD>SearchReplaceMultiBufferCWord<CR>", "[w]ord" }
 keymap["r"]["b"]["W"] = { "<CMD>SearchReplaceMultiBufferCWORD<CR>", "[W]ORD" }

--- a/README.md
+++ b/README.md
@@ -271,8 +271,14 @@ lvim.builtin.which_key.mappings
   config = function()
     require("search-replace").setup({
       -- optionally override defaults
-      default_replace_single_buffer_options = "gcI",
-      default_replace_multi_buffer_options = "egcI",
+      single_buffer = {
+        range = "%",
+        flags = "gcI",
+      },
+      multi_buffer = {
+        range = "%",
+        flags = "egcI",
+      },
     })
   end,
 }
@@ -286,8 +292,14 @@ use({
   config = function()
     require("search-replace").setup({
       -- optionally override defaults
-      default_replace_single_buffer_options = "gcI",
-      default_replace_multi_buffer_options = "egcI",
+      single_buffer = {
+        range = "%",
+        flags = "gcI",
+      },
+      multi_buffer = {
+        range = "%",
+        flags = "egcI",
+      },
     })
   end,
 })

--- a/lua/search-replace/config.lua
+++ b/lua/search-replace/config.lua
@@ -1,8 +1,14 @@
 local M = {}
 
 M.options = {
-	default_replace_single_buffer_options = "gcI",
-	default_replace_multi_buffer_options = "egcI",
+	single_buffer = {
+		range = "%",
+		flags = "gcI",
+	},
+	multi_buffer = {
+		range = "%",
+		flags = "egcI",
+	},
 }
 
 return M

--- a/lua/search-replace/multi-buffer.lua
+++ b/lua/search-replace/multi-buffer.lua
@@ -15,14 +15,14 @@ M.search_replace = function(pattern, opts)
 	end
 
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options.multi_buffer.flags) + shift)
+		string.rep("\\<Left>", string.len(opts.flags or config.options.multi_buffer.flags) + shift)
 	vim.cmd(
 		':call feedkeys(":bufdo '
-			.. opts.range or config.options.single_buffer.range
+			.. (opts.range or config.options.single_buffer.range)
 			.. 's/'
 			.. util.double_escape(pattern)
 			.. "//"
-			.. opts.flags or config.options.multi_buffer.flags
+			.. (opts.flags or config.options.multi_buffer.flags)
 			.. left_keypresses
 			.. '")'
 	)
@@ -40,16 +40,16 @@ M.visual_charwise_selection = function(opts)
 
 	local backspace_keypresses = string.rep("\\<backspace>", 5)
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options.multi_buffer.flags) + 1)
+		string.rep("\\<Left>", string.len(opts.flags or config.options.multi_buffer.flags) + 1)
 
 	vim.cmd(
 		':call feedkeys(":'
 			.. backspace_keypresses
-			.. opts.range or config.options.single_buffer.range
+			.. (opts.range or config.options.single_buffer.range)
 			.. "s/"
 			.. util.double_escape(visual_selection)
 			.. "//"
-			.. opts.flags or config.options.multi_buffer.flags
+			.. (opts.flags or config.options.multi_buffer.flags)
 			.. left_keypresses
 			.. '")'
 	)

--- a/lua/search-replace/multi-buffer.lua
+++ b/lua/search-replace/multi-buffer.lua
@@ -3,7 +3,9 @@ local M = {}
 local util = require("search-replace.util")
 local config = require("search-replace.config")
 
-M.search_replace = function(pattern)
+M.search_replace = function(pattern, opts)
+	opts = opts or {}
+
 	local shift = 0
 
 	if string.len(pattern) == 0 then
@@ -13,18 +15,22 @@ M.search_replace = function(pattern)
 	end
 
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options["default_replace_multi_buffer_options"]) + shift)
+		string.rep("\\<Left>", string.len(config.options.multi_buffer.flags) + shift)
 	vim.cmd(
-		':call feedkeys(":bufdo %s/'
+		':call feedkeys(":bufdo '
+			.. opts.range or config.options.single_buffer.range
+			.. 's/'
 			.. util.double_escape(pattern)
 			.. "//"
-			.. config.options["default_replace_multi_buffer_options"]
+			.. opts.flags or config.options.multi_buffer.flags
 			.. left_keypresses
 			.. '")'
 	)
 end
 
-M.visual_charwise_selection = function()
+M.visual_charwise_selection = function(opts)
+	opts = opts or {}
+
 	local visual_selection = util.get_visual_selection()
 
 	if visual_selection == nil then
@@ -34,38 +40,39 @@ M.visual_charwise_selection = function()
 
 	local backspace_keypresses = string.rep("\\<backspace>", 5)
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options["default_replace_multi_buffer_options"]) + 1)
+		string.rep("\\<Left>", string.len(config.options.multi_buffer.flags) + 1)
 
 	vim.cmd(
 		':call feedkeys(":'
 			.. backspace_keypresses
-			.. "%s/"
+			.. opts.range or config.options.single_buffer.range
+			.. "s/"
 			.. util.double_escape(visual_selection)
 			.. "//"
-			.. config.options["default_replace_multi_buffer_options"]
+			.. opts.flags or config.options.multi_buffer.flags
 			.. left_keypresses
 			.. '")'
 	)
 end
 
-M.open = function()
-	M.search_replace("")
+M.open = function(opts)
+	M.search_replace("", opts)
 end
 
-M.cword = function()
-	M.search_replace(vim.fn.expand("<cword>"))
+M.cword = function(opts)
+	M.search_replace(vim.fn.expand("<cword>"), opts)
 end
 
-M.cWORD = function()
-	M.search_replace(vim.fn.expand("<cWORD>"))
+M.cWORD = function(opts)
+	M.search_replace(vim.fn.expand("<cWORD>"), opts)
 end
 
-M.cexpr = function()
-	M.search_replace(vim.fn.expand("<cexpr>"))
+M.cexpr = function(opts)
+	M.search_replace(vim.fn.expand("<cexpr>"), opts)
 end
 
-M.cfile = function()
-	M.search_replace(vim.fn.expand("<cfile>"))
+M.cfile = function(opts)
+	M.search_replace(vim.fn.expand("<cfile>"), opts)
 end
 
 return M

--- a/lua/search-replace/single-buffer.lua
+++ b/lua/search-replace/single-buffer.lua
@@ -15,14 +15,14 @@ M.search_replace = function(pattern, opts)
 	end
 
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options.single_buffer.flags) + shift)
+		string.rep("\\<Left>", string.len(opts.flags or config.options.single_buffer.flags) + shift)
 	vim.cmd(
 		':call feedkeys(":'
-			.. opts.range or config.options.single_buffer.range
+			.. (opts.range or config.options.single_buffer.range)
 			.. 's/'
 			.. util.double_escape(pattern)
 			.. "//"
-			.. opts.flags or config.options.single_buffer.flags
+			.. (opts.flags or config.options.single_buffer.flags)
 			.. left_keypresses
 			.. '")'
 	)
@@ -40,16 +40,16 @@ M.visual_charwise_selection = function(opts)
 
 	local backspace_keypresses = string.rep("\\<backspace>", 5)
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options.single_buffer.flags) + 1)
+		string.rep("\\<Left>", string.len(opts.flags or config.options.single_buffer.flags) + 1)
 
 	vim.cmd(
 		':call feedkeys(":'
 			.. backspace_keypresses
-			.. opts.range or config.options.single_buffer.range
+			.. (opts.range or config.options.single_buffer.range)
 			.. "s/"
 			.. util.double_escape(visual_selection)
 			.. "//"
-			.. opts.flags or config.options.single_buffer.flags
+			.. (opts.flags or config.options.single_buffer.flags)
 			.. left_keypresses
 			.. '")'
 	)

--- a/lua/search-replace/single-buffer.lua
+++ b/lua/search-replace/single-buffer.lua
@@ -3,7 +3,9 @@ local M = {}
 local util = require("search-replace.util")
 local config = require("search-replace.config")
 
-M.search_replace = function(pattern)
+M.search_replace = function(pattern, opts)
+	opts = opts or {}
+
 	local shift = 0
 
 	if string.len(pattern) == 0 then
@@ -13,18 +15,22 @@ M.search_replace = function(pattern)
 	end
 
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options["default_replace_single_buffer_options"]) + shift)
+		string.rep("\\<Left>", string.len(config.options.single_buffer.flags) + shift)
 	vim.cmd(
-		':call feedkeys(":%s/'
+		':call feedkeys(":'
+			.. opts.range or config.options.single_buffer.range
+			.. 's/'
 			.. util.double_escape(pattern)
 			.. "//"
-			.. config.options["default_replace_single_buffer_options"]
+			.. opts.flags or config.options.single_buffer.flags
 			.. left_keypresses
 			.. '")'
 	)
 end
 
-M.visual_charwise_selection = function()
+M.visual_charwise_selection = function(opts)
+	opts = opts or {}
+
 	local visual_selection = util.get_visual_selection()
 
 	if visual_selection == nil then
@@ -34,38 +40,39 @@ M.visual_charwise_selection = function()
 
 	local backspace_keypresses = string.rep("\\<backspace>", 5)
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options["default_replace_single_buffer_options"]) + 1)
+		string.rep("\\<Left>", string.len(config.options.single_buffer.flags) + 1)
 
 	vim.cmd(
 		':call feedkeys(":'
 			.. backspace_keypresses
-			.. "%s/"
+			.. opts.range or config.options.single_buffer.range
+			.. "s/"
 			.. util.double_escape(visual_selection)
 			.. "//"
-			.. config.options["default_replace_single_buffer_options"]
+			.. opts.flags or config.options.single_buffer.flags
 			.. left_keypresses
 			.. '")'
 	)
 end
 
-M.open = function()
-	M.search_replace("")
+M.open = function(opts)
+	M.search_replace("", opts)
 end
 
-M.cword = function()
-	M.search_replace(vim.fn.expand("<cword>"))
+M.cword = function(opts)
+	M.search_replace(vim.fn.expand("<cword>"), opts)
 end
 
-M.cWORD = function()
-	M.search_replace(vim.fn.expand("<cWORD>"))
+M.cWORD = function(opts)
+	M.search_replace(vim.fn.expand("<cWORD>"), opts)
 end
 
-M.cexpr = function()
-	M.search_replace(vim.fn.expand("<cexpr>"))
+M.cexpr = function(opts)
+	M.search_replace(vim.fn.expand("<cexpr>"), opts)
 end
 
-M.cfile = function()
-	M.search_replace(vim.fn.expand("<cfile>"))
+M.cfile = function(opts)
+	M.search_replace(vim.fn.expand("<cfile>"), opts)
 end
 
 return M

--- a/lua/search-replace/visual-multitype.lua
+++ b/lua/search-replace/visual-multitype.lua
@@ -13,13 +13,13 @@ local within = function(pattern)
 	end
 
 	local left_keypresses =
-		string.rep("\\<Left>", string.len(config.options["default_replace_single_buffer_options"]) + shift)
+		string.rep("\\<Left>", string.len(config.options.single_buffer.flags) + shift)
 
 	vim.cmd(
 		':call feedkeys(":s/'
 			.. util.double_escape(pattern)
 			.. "//"
-			.. config.options["default_replace_single_buffer_options"]
+			.. config.options.single_buffer.flags
 			.. left_keypresses
 			.. '")'
 	)


### PR DESCRIPTION
I'd read the issue #3 and had thought that make senses.

Now, with this commit, plugins can works normally. And if some peoples want to configure  'range' or 'flags' respectively then they can pass the table like:
```lua
require("search-replace.single-buffer").cword({ range = "1,100", flags = "c" })
```
There is backward compatibility because param opts are optional and gets form overrided default value by user or default if received param don't exists. Also the README updated, added section for configuring using clear lua and updated configuration.